### PR TITLE
Fix userlistgrid

### DIFF
--- a/src/Components/UserListGrid.tsx
+++ b/src/Components/UserListGrid.tsx
@@ -81,7 +81,13 @@ const onRowEdit = (accounts: AccountsType[], state: GridEditRowsModel) => {
     account = Object.assign(account, accountNewFields);
 
     // Update `account`
-    PutAccounts(account);
+    PutAccounts(account)
+      .then(() => {
+        // TODO: accounts updated successfuly
+      })
+      .catch(() => {
+        // TODO: could not update accounts
+      });
   }
 };
 


### PR DESCRIPTION
I did 3 different commits. I suggest you reading each of them separately to understand what I did. But basically this pull request:

- moved the onRowEdit logic into a separate function
- used `Object.assign()` to merge two objects (existing account object with update object)
- called PutAccounts() with the new, merged object